### PR TITLE
[fix] Multiple typos in cpp and h files

### DIFF
--- a/counties/County.h
+++ b/counties/County.h
@@ -1,7 +1,12 @@
+#ifndef COUNTY_H
+#define COUNTY_H
 #include <string>
 
 class County {
 	public:
 		int population;
 		std::string name;
-}
+};
+
+#endif
+

--- a/counties/CountyMap.cpp
+++ b/counties/CountyMap.cpp
@@ -2,7 +2,7 @@
 #include "County.h"
 #include <vector>
 
-CountyMap(vector<County> counties, vector<vector<bool>> adjMatrix) {
+CountyMap::CountyMap(vector<County> counties, vector<vector<bool>> adjMatrix) {
     // TODO
 }
 
@@ -18,7 +18,7 @@ County CountyMap::getCounty(int index) {
     // TODO
 }
 
-int getNumCounties() {
+int CountyMap::getNumCounties() {
     // TODO
 }
 

--- a/counties/CountyMap.h
+++ b/counties/CountyMap.h
@@ -4,6 +4,8 @@
 #include <vector>
 #include "County.h"
 
+using namespace std;
+
 class CountyMap {
 	private:
 		//storage requirement: O(e), e = number of edges between counties
@@ -13,6 +15,10 @@ class CountyMap {
 		//constructor
 		//performance: O(n^2), n = number of counties
 		CountyMap(vector<County> counties, vector<vector<bool>> adjacencyMatrix);
+
+		CountyMap(const CountyMap& other) ;
+
+		~CountyMap();
 
 		//performance: O(1)
 		County getCounty(int countyID);
@@ -28,4 +34,6 @@ class CountyMap {
 
 		//performance: O(n), n = number of counties in the itinerary
 		bool checkValidItinerary(vector<int> itinerary);
-}
+};
+
+#endif


### PR DESCRIPTION
Fixed:
H file header guard
Namespace in h files
Missing declaration of copy constructor
Missing declaration of destructor
Missing scope for getNumCounties and constructor